### PR TITLE
Fix pint/(X instances) cache error

### DIFF
--- a/system_query/cpu_info.py
+++ b/system_query/cpu_info.py
@@ -38,6 +38,9 @@ def _get_cache_size(level: int, cpuinfo_data: dict) -> t.Optional[int]:
     if raw_value is None:
         return None
     assert isinstance(raw_value, str), (type(raw_value), raw_value)
+    # Sometimes cpuinfo prints e.g. `192 KiB (6 instances)` so we use
+    # just the first two words
+    raw_value = " ".join(raw_value.split()[:2])
     # KB, MB: "this practice frequently leads to confusion and is deprecated"
     # see https://en.wikipedia.org/wiki/JEDEC_memory_standards
     if raw_value.endswith('KB'):


### PR DESCRIPTION
On my AMD Ryzen 5 5600X 6-Core cpu, `py-cpuinfo` was returning `192 KiB (6 instances)` which got `pint` confused since it is expecting only `192 KiB`.  My solution is to keep only the first two "words" (i.e. number and unit) and throw away the rest.